### PR TITLE
Background task

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ if Context.environment["SKIP_BRIDGE"] ?? "0" != "0" {
     package.dependencies += [.package(url: "https://source.skip.tools/skip-bridge.git", "0.0.0"..<"2.0.0")]
     package.targets.forEach({ target in
         target.dependencies += [.product(name: "SkipBridge", package: "skip-bridge")]
+        target.swiftSettings = (target.swiftSettings ?? []) + [.define("SKIP_BRIDGE")]
     })
     // all library types must be dynamic to support bridging
     package.products = package.products.map({ product in
@@ -34,4 +35,3 @@ if Context.environment["SKIP_BRIDGE"] ?? "0" != "0" {
         return .library(name: libraryProduct.name, type: .dynamic, targets: libraryProduct.targets)
     })
 }
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SkipDevice
 
 The SkipDevice module is a dual-platform [Skip](https://skip.dev) framework that provides access to
-network reachability, location services, and device sensor data (accelerometer, gyroscope, magnetometer, and barometer).
+network reachability, location services, app runtime events, finite background activity, and device sensor data (accelerometer, gyroscope, magnetometer, and barometer).
 
 On iOS, the module wraps [CoreMotion](https://developer.apple.com/documentation/coremotion) and [CoreLocation](https://developer.apple.com/documentation/corelocation). On Android, it wraps the [Sensor](https://developer.android.com/reference/android/hardware/SensorManager) and [Location](https://developer.android.com/reference/android/location/LocationManager) APIs. All sensor providers expose a unified `AsyncThrowingStream` interface that works identically on both platforms.
 
@@ -179,6 +179,91 @@ Android manifest entries:
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 ```
+
+## Application Runtime Events
+
+Monitor app lifecycle and memory pressure events through a single API on both platforms.
+
+| | iOS / tvOS | Android |
+|---|---|---|
+| Lifecycle API | `UIApplication` notifications | `Application.ActivityLifecycleCallbacks` |
+| Memory API | `UIApplication.didReceiveMemoryWarningNotification` | `ComponentCallbacks2` |
+
+```swift
+import SkipDevice
+
+let provider = ApplicationRuntimeProvider()
+
+Task {
+    for await event in provider.monitorLifecycle() {
+        print("phase: \(event.phase.rawValue)")
+    }
+}
+
+Task {
+    for await event in provider.monitorMemoryPressure() {
+        print("memory pressure: \(event.level.rawValue)")
+    }
+}
+```
+
+Call `provider.stop()` when the owning feature no longer needs runtime events. Unsupported Apple platforms compile and report `.unknown` lifecycle phase with no platform callbacks.
+
+Android memory pressure maps `onLowMemory`, `TRIM_MEMORY_RUNNING_CRITICAL`, and `TRIM_MEMORY_COMPLETE` to `.critical`; other trim-memory pressure callbacks map to `.warning`.
+
+## Background Activity
+
+Begin and end finite user-visible background work. This is not a guarantee of indefinite execution: the app still owns completing work promptly and ending the activity.
+
+```swift
+import SkipDevice
+
+let identifier = try await BackgroundActivity.begin(BackgroundActivityRequest(
+    name: "Syncing media",
+    reason: BackgroundActivityReason.localNetworkTransfer,
+    detail: "Keeping the transfer active"
+))
+
+await performTransfer()
+await BackgroundActivity.end(identifier)
+```
+
+Use `do` / `catch` or task cancellation handling in app code so `BackgroundActivity.end(_:)` runs on success, failure, and cancellation.
+
+### Background Activity Reasons
+
+| Reason | Android foreground service type |
+|---|---|
+| `localNetworkTransfer` | `dataSync` |
+| `mediaProcessing` | `mediaProcessing` on Android 15+, `dataSync` on older Android versions |
+| `connectedDeviceTransfer` | `connectedDevice` |
+| `shortCriticalWork` | `shortService` when available, `dataSync` on older Android versions |
+
+On iOS and tvOS, `BackgroundActivity` wraps `UIApplication.beginBackgroundTask(withName:expirationHandler:)` and `UIApplication.endBackgroundTask(_:)`.
+
+On Android, `BackgroundActivity` starts `skip.device.BackgroundActivityService` as a foreground service. Android 15 limits `dataSync` and `mediaProcessing` foreground services to 6 hours per 24 hours; the service implements `Service.onTimeout(int, int)` and stops promptly when Android reports a timeout.
+
+### Background Activity Android Manifest
+
+Apps using `BackgroundActivity` must declare the foreground service and the service-type permissions needed by their chosen reasons:
+
+```xml
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROCESSING" />
+
+<application>
+    <service
+        android:name="skip.device.BackgroundActivityService"
+        android:exported="false"
+        android:foregroundServiceType="dataSync|mediaProcessing|connectedDevice|shortService" />
+</application>
+```
+
+`shortService` does not have a type-specific permission, but it still requires `FOREGROUND_SERVICE`. `connectedDevice` has additional Android runtime prerequisites depending on the device transport, such as Bluetooth, NFC, USB, or network-change capabilities. The app owns any extra runtime permissions required for its use case.
+
+The default Android notification icon resource is `ic_notification`. Apps can provide a different drawable resource through `BackgroundActivityRequest.notificationIconResourceName`. Notification text, icon design, Android notification permission flow, and Google Play foreground-service policy justification remain app-owned.
 
 ## Motion Sensors
 
@@ -424,6 +509,7 @@ Set `android:required="false"` so the app can still be installed on devices with
 |---|---|---|---|---|
 | Network Reachability | None | None | `ACCESS_NETWORK_STATE` | None |
 | Location | `NSLocationWhenInUseUsageDescription` | Yes (via `PermissionManager`) | `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` | Yes (via `PermissionManager`) |
+| Background Activity | None | None | `FOREGROUND_SERVICE` plus selected foreground-service type permissions | App-owned by use case |
 | Accelerometer | `NSMotionUsageDescription` | None | None | None |
 | Gyroscope | `NSMotionUsageDescription` | None | None | None |
 | Magnetometer | `NSMotionUsageDescription` | None | None | None |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SkipDevice
 
 The SkipDevice module is a dual-platform [Skip](https://skip.dev) framework that provides access to
-network reachability, location services, app runtime events, finite background activity, and device sensor data (accelerometer, gyroscope, magnetometer, and barometer).
+network reachability, device identity, location services, app runtime events, finite background activity, and device sensor data (accelerometer, gyroscope, magnetometer, and barometer).
 
 On iOS, the module wraps [CoreMotion](https://developer.apple.com/documentation/coremotion) and [CoreLocation](https://developer.apple.com/documentation/corelocation). On Android, it wraps the [Sensor](https://developer.android.com/reference/android/hardware/SensorManager) and [Location](https://developer.android.com/reference/android/location/LocationManager) APIs. All sensor providers expose a unified `AsyncThrowingStream` interface that works identically on both platforms.
 
@@ -76,6 +76,24 @@ Android manifest entry:
 ```xml
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 ```
+
+## Device Identity
+
+Read low-level device identity fields from the current platform.
+
+| | iOS / tvOS | Android |
+|---|---|---|
+| API | `UIDevice` | `Build`, `Settings.Global`, `Settings.Secure` |
+
+```swift
+import SkipDevice
+
+let identity = DeviceIdentity.current
+print(identity.name ?? "Unnamed device")
+print(identity.model ?? "Unknown model")
+```
+
+`vendorIdentifier` maps to `UIDevice.identifierForVendor` on Apple platforms and `Settings.Secure.ANDROID_ID` on Android. Treat it as privacy-sensitive app data; app-specific policy, disclosure, and storage choices remain app-owned.
 
 ## Location
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ let provider = ApplicationRuntimeProvider()
 
 Task {
     for await event in provider.monitorLifecycle() {
-        print("phase: \(event.phase.rawValue)")
+        print("event: \(event.kind.rawValue), phase: \(event.phase.rawValue)")
     }
 }
 
@@ -207,7 +207,7 @@ Task {
 }
 ```
 
-Call `provider.stop()` when the owning feature no longer needs runtime events. Unsupported Apple platforms compile and report `.unknown` lifecycle phase with no platform callbacks.
+`event.kind` preserves an iOS-style lifecycle event name where possible, while `event.phase` gives callers a normalized foreground/background phase. Call `provider.stop()` when the owning feature no longer needs runtime events. Unsupported Apple platforms compile and report `.unknown` lifecycle phase with no platform callbacks.
 
 Android memory pressure maps `onLowMemory`, `TRIM_MEMORY_RUNNING_CRITICAL`, and `TRIM_MEMORY_COMPLETE` to `.critical`; other trim-memory pressure callbacks map to `.warning`.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # SkipDevice
 
 The SkipDevice module is a dual-platform [Skip](https://skip.dev) framework that provides access to
-network reachability, device identity, location services, app runtime events, finite background activity, and device sensor data (accelerometer, gyroscope, magnetometer, and barometer).
+network reachability, device identity, location services, app runtime events, finite background activity,
+and device sensor data (accelerometer, gyroscope, magnetometer, and barometer).
 
-On iOS, the module wraps [CoreMotion](https://developer.apple.com/documentation/coremotion) and [CoreLocation](https://developer.apple.com/documentation/corelocation). On Android, it wraps the [Sensor](https://developer.android.com/reference/android/hardware/SensorManager) and [Location](https://developer.android.com/reference/android/location/LocationManager) APIs. All sensor providers expose a unified `AsyncThrowingStream` interface that works identically on both platforms.
+On Apple platforms, the module wraps platform APIs such as
+[UIKit](https://developer.apple.com/documentation/uikit),
+[CoreMotion](https://developer.apple.com/documentation/coremotion),
+[CoreLocation](https://developer.apple.com/documentation/corelocation), and
+[SystemConfiguration](https://developer.apple.com/documentation/systemconfiguration).
+On Android, it wraps platform APIs such as
+[`Build`](https://developer.android.com/reference/android/os/Build),
+[`Application`](https://developer.android.com/reference/android/app/Application),
+[`Service`](https://developer.android.com/reference/android/app/Service),
+[`SensorManager`](https://developer.android.com/reference/android/hardware/SensorManager),
+[`LocationManager`](https://developer.android.com/reference/android/location/LocationManager), and
+[`ConnectivityManager`](https://developer.android.com/reference/android/net/ConnectivityManager).
+
+All sensor providers expose a unified `AsyncThrowingStream` interface that works identically on both platforms.
 
 ## Setup
 
@@ -27,7 +41,7 @@ let package = Package(
 )
 ```
 
-## Usage Pattern
+## Sensor Usage Pattern
 
 All sensor providers follow the same pattern:
 
@@ -94,6 +108,21 @@ print(identity.model ?? "Unknown model")
 ```
 
 `vendorIdentifier` maps to `UIDevice.identifierForVendor` on Apple platforms and `Settings.Secure.ANDROID_ID` on Android. Treat it as privacy-sensitive app data; app-specific policy, disclosure, and storage choices remain app-owned.
+
+### DeviceIdentity Properties
+
+| Property | Description |
+|---|---|
+| `name` | User-visible device name when the platform exposes one |
+| `model` | Platform model string |
+| `localizedModel` | Localized Apple model string when available |
+| `systemName` | Platform operating system name |
+| `systemVersion` | Platform operating system version |
+| `vendorIdentifier` | App/vendor-scoped stable identifier when available |
+| `manufacturer` | Device manufacturer, such as `Apple`, `Google`, or `Samsung` |
+| `brand` | Android `Build.BRAND` when available |
+| `device` | Android `Build.DEVICE` when available |
+| `product` | Android `Build.PRODUCT` when available |
 
 ## Location
 
@@ -229,6 +258,16 @@ Task {
 
 Android memory pressure maps `onLowMemory`, `TRIM_MEMORY_RUNNING_CRITICAL`, and `TRIM_MEMORY_COMPLETE` to `.critical`; other trim-memory pressure callbacks map to `.warning`.
 
+### Runtime Event Values
+
+| Type | Values |
+|---|---|
+| `ApplicationLifecyclePhase` | `active`, `inactive`, `background`, `terminated`, `unknown` |
+| `ApplicationLifecycleEventKind` | `didBecomeActive`, `willResignActive`, `didEnterBackground`, `willTerminate`, `unknown` |
+| `MemoryPressureLevel` | `warning`, `critical` |
+
+`monitorLifecycle()` immediately yields the most recently known lifecycle event. On Android this is initially `.unknown` until an activity lifecycle callback is observed. On Apple platforms, the initial phase is read from `UIApplication.shared.applicationState` when available on the main thread; otherwise it starts as `.unknown`.
+
 ## Background Activity
 
 Begin and end finite user-visible background work. This is not a guarantee of indefinite execution: the app still owns completing work promptly and ending the activity.
@@ -247,6 +286,17 @@ await BackgroundActivity.end(identifier)
 ```
 
 Use `do` / `catch` or task cancellation handling in app code so `BackgroundActivity.end(_:)` runs on success, failure, and cancellation.
+
+### BackgroundActivityRequest Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `name` | Required | User-visible activity name |
+| `reason` | `shortCriticalWork` | Platform reason used to choose the Android foreground-service type |
+| `detail` | Empty string | Optional user-visible detail for the Android foreground notification |
+| `notificationChannelID` | `tools.skip.device.background_activity` | Android notification channel identifier |
+| `notificationID` | `41001` | Android foreground notification identifier |
+| `notificationIconResourceName` | `ic_notification` | Android drawable resource name for the foreground notification icon |
 
 ### Background Activity Reasons
 
@@ -523,10 +573,12 @@ Set `android:required="false"` so the app can still be installed on devices with
 
 ## Permissions Summary
 
-| Sensor | iOS Declaration | iOS Runtime | Android Declaration | Android Runtime |
+| Capability | iOS Declaration | iOS Runtime | Android Declaration | Android Runtime |
 |---|---|---|---|---|
 | Network Reachability | None | None | `ACCESS_NETWORK_STATE` | None |
+| Device Identity | None | None | None | None |
 | Location | `NSLocationWhenInUseUsageDescription` | Yes (via `PermissionManager`) | `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` | Yes (via `PermissionManager`) |
+| Application Runtime Events | None | None | None | None |
 | Background Activity | None | None | `FOREGROUND_SERVICE` plus selected foreground-service type permissions | App-owned by use case |
 | Accelerometer | `NSMotionUsageDescription` | None | None | None |
 | Gyroscope | `NSMotionUsageDescription` | None | None | None |
@@ -535,16 +587,19 @@ Set `android:required="false"` so the app can still be installed on devices with
 
 ## API Reference
 
-| Provider | Event Type | Key Properties | `isAvailable` | `updateInterval` |
+| API | Event / Value Type | Key Properties | `isAvailable` | `updateInterval` |
 |---|---|---|---|---|
 | `NetworkReachability` | -- | `.isNetworkReachable: Bool` (static) | -- | -- |
+| `DeviceIdentity` | `DeviceIdentity` | `.current`, name, model, system, vendor, Android build fields | -- | -- |
 | `LocationProvider` | `LocationEvent` | latitude, longitude, altitude, speed, course, accuracy | Yes | No (1s default) |
+| `ApplicationRuntimeProvider` | `ApplicationLifecycleEvent`, `MemoryPressureEvent` | lifecycle phase/kind, memory pressure level | -- | -- |
+| `BackgroundActivity` | `BackgroundActivityRequest` | `begin(_:)`, `end(_:)`, reason, notification metadata | -- | -- |
 | `AccelerometerProvider` | `AccelerometerEvent` | x, y, z (G's) | Yes | Yes |
 | `GyroscopeProvider` | `GyroscopeEvent` | x, y, z (rad/s) | Yes | Yes |
 | `MagnetometerProvider` | `MagnetometerEvent` | x, y, z (microteslas) | Yes | Yes |
 | `BarometerProvider` | `BarometerEvent` | pressure (kPa), relativeAltitude (m) | Yes | Yes |
 
-All sensor providers share the same interface:
+Sensor providers share the same interface:
 
 | Method / Property | Description |
 |---|---|

--- a/Sources/SkipDevice/ApplicationRuntimeProvider.swift
+++ b/Sources/SkipDevice/ApplicationRuntimeProvider.swift
@@ -29,11 +29,14 @@ public final class ApplicationRuntimeProvider: @unchecked Sendable {
     private let lock = NSLock()
     private var lifecycleMonitors: [LifecycleMonitor] = []
     private var memoryMonitors: [MemoryMonitor] = []
-    private var lifecyclePhase: ApplicationLifecyclePhase = .unknown
+    private var lifecycleEvent = ApplicationLifecycleEvent(
+        kind: ApplicationLifecycleEventKind.unknown,
+        phase: ApplicationLifecyclePhase.unknown
+    )
 
     public init() {
         #if !SKIP
-        lifecyclePhase = Self.initialLifecyclePhase()
+        lifecycleEvent = ApplicationLifecycleEvent(phase: Self.initialLifecyclePhase())
         #endif
         start()
     }
@@ -45,7 +48,7 @@ public final class ApplicationRuntimeProvider: @unchecked Sendable {
     /// The most recently observed app lifecycle phase.
     public var currentLifecyclePhase: ApplicationLifecyclePhase {
         lock.lock()
-        let phase = lifecyclePhase
+        let phase = lifecycleEvent.phase
         lock.unlock()
         return phase
     }
@@ -64,9 +67,9 @@ public final class ApplicationRuntimeProvider: @unchecked Sendable {
                     continuation.finish()
                 }
             ))
-            let phase = lifecyclePhase
+            let event = lifecycleEvent
             lock.unlock()
-            continuation.yield(ApplicationLifecycleEvent(phase: phase))
+            continuation.yield(event)
             continuation.onTermination = { [weak self] _ in
                 self?.removeLifecycleContinuation(id)
             }
@@ -123,8 +126,30 @@ public final class ApplicationRuntimeProvider: @unchecked Sendable {
 
     func publishLifecycle(_ phase: ApplicationLifecyclePhase) {
         let event = ApplicationLifecycleEvent(phase: phase)
+        publishLifecycle(kind: event.kind, phase: event.phase)
+    }
+
+    func publishLifecycle(_ kind: ApplicationLifecycleEventKind) {
+        let phase: ApplicationLifecyclePhase
+        switch kind {
+        case ApplicationLifecycleEventKind.didBecomeActive:
+            phase = ApplicationLifecyclePhase.active
+        case ApplicationLifecycleEventKind.willResignActive:
+            phase = ApplicationLifecyclePhase.inactive
+        case ApplicationLifecycleEventKind.didEnterBackground:
+            phase = ApplicationLifecyclePhase.background
+        case ApplicationLifecycleEventKind.willTerminate:
+            phase = ApplicationLifecyclePhase.terminated
+        case ApplicationLifecycleEventKind.unknown:
+            phase = ApplicationLifecyclePhase.unknown
+        }
+        publishLifecycle(kind: kind, phase: phase)
+    }
+
+    private func publishLifecycle(kind: ApplicationLifecycleEventKind, phase: ApplicationLifecyclePhase) {
+        let event = ApplicationLifecycleEvent(kind: kind, phase: phase)
         lock.lock()
-        lifecyclePhase = phase
+        lifecycleEvent = event
         let monitors = lifecycleMonitors
         lock.unlock()
         for monitor in monitors {
@@ -181,16 +206,16 @@ public final class ApplicationRuntimeProvider: @unchecked Sendable {
         #if canImport(UIKit)
         let center = NotificationCenter.default
         notificationObservers.append(center.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
-            self?.publishLifecycle(ApplicationLifecyclePhase.active)
+            self?.publishLifecycle(ApplicationLifecycleEventKind.didBecomeActive)
         })
         notificationObservers.append(center.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: nil) { [weak self] _ in
-            self?.publishLifecycle(ApplicationLifecyclePhase.inactive)
+            self?.publishLifecycle(ApplicationLifecycleEventKind.willResignActive)
         })
         notificationObservers.append(center.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { [weak self] _ in
-            self?.publishLifecycle(ApplicationLifecyclePhase.background)
+            self?.publishLifecycle(ApplicationLifecycleEventKind.didEnterBackground)
         })
         notificationObservers.append(center.addObserver(forName: UIApplication.willTerminateNotification, object: nil, queue: nil) { [weak self] _ in
-            self?.publishLifecycle(ApplicationLifecyclePhase.terminated)
+            self?.publishLifecycle(ApplicationLifecycleEventKind.willTerminate)
         })
         notificationObservers.append(center.addObserver(forName: UIApplication.didReceiveMemoryWarningNotification, object: nil, queue: nil) { [weak self] _ in
             self?.publishMemoryPressure(MemoryPressureLevel.warning)
@@ -245,6 +270,15 @@ public enum ApplicationLifecyclePhase: String, Hashable, Sendable {
     case unknown
 }
 
+/// A platform lifecycle event kind, named to match iOS lifecycle notifications where possible.
+public enum ApplicationLifecycleEventKind: String, Hashable, Sendable {
+    case didBecomeActive
+    case willResignActive
+    case didEnterBackground
+    case willTerminate
+    case unknown
+}
+
 /// A coarse memory pressure level.
 public enum MemoryPressureLevel: String, Hashable, Sendable {
     case warning
@@ -253,12 +287,36 @@ public enum MemoryPressureLevel: String, Hashable, Sendable {
 
 /// An app lifecycle event.
 public struct ApplicationLifecycleEvent: Hashable, Sendable {
+    /// The raw lifecycle event kind that was observed.
+    public var kind: ApplicationLifecycleEventKind
     /// The lifecycle phase that was observed.
     public var phase: ApplicationLifecyclePhase
     /// The event timestamp in seconds since 1970.
     public var timestamp: TimeInterval
 
+    public init(
+        kind: ApplicationLifecycleEventKind,
+        phase: ApplicationLifecyclePhase,
+        timestamp: TimeInterval = Date().timeIntervalSince1970
+    ) {
+        self.kind = kind
+        self.phase = phase
+        self.timestamp = timestamp
+    }
+
     public init(phase: ApplicationLifecyclePhase, timestamp: TimeInterval = Date().timeIntervalSince1970) {
+        switch phase {
+        case ApplicationLifecyclePhase.active:
+            self.kind = ApplicationLifecycleEventKind.didBecomeActive
+        case ApplicationLifecyclePhase.inactive:
+            self.kind = ApplicationLifecycleEventKind.willResignActive
+        case ApplicationLifecyclePhase.background:
+            self.kind = ApplicationLifecycleEventKind.didEnterBackground
+        case ApplicationLifecyclePhase.terminated:
+            self.kind = ApplicationLifecycleEventKind.willTerminate
+        case ApplicationLifecyclePhase.unknown:
+            self.kind = ApplicationLifecycleEventKind.unknown
+        }
         self.phase = phase
         self.timestamp = timestamp
     }
@@ -301,7 +359,7 @@ private final class ApplicationRuntimeAndroidObserver: Application.ActivityLifec
 
     override func onActivityResumed(activity: Activity) {
         resumedActivities += 1
-        provider?.publishLifecycle(ApplicationLifecyclePhase.active)
+        provider?.publishLifecycle(ApplicationLifecycleEventKind.didBecomeActive)
     }
 
     override func onActivityPaused(activity: Activity) {
@@ -309,7 +367,7 @@ private final class ApplicationRuntimeAndroidObserver: Application.ActivityLifec
             resumedActivities -= 1
         }
         if resumedActivities == 0 && startedActivities > 0 {
-            provider?.publishLifecycle(ApplicationLifecyclePhase.inactive)
+            provider?.publishLifecycle(ApplicationLifecycleEventKind.willResignActive)
         }
     }
 
@@ -318,13 +376,13 @@ private final class ApplicationRuntimeAndroidObserver: Application.ActivityLifec
             startedActivities -= 1
         }
         if startedActivities == 0 {
-            provider?.publishLifecycle(ApplicationLifecyclePhase.background)
+            provider?.publishLifecycle(ApplicationLifecycleEventKind.didEnterBackground)
         }
     }
 
     override func onActivityDestroyed(activity: Activity) {
         if activity.isFinishing && startedActivities == 0 {
-            provider?.publishLifecycle(ApplicationLifecyclePhase.terminated)
+            provider?.publishLifecycle(ApplicationLifecycleEventKind.willTerminate)
         }
     }
 
@@ -332,7 +390,7 @@ private final class ApplicationRuntimeAndroidObserver: Application.ActivityLifec
     override func onActivityStarted(activity: Activity) {
         startedActivities += 1
         if resumedActivities == 0 {
-            provider?.publishLifecycle(ApplicationLifecyclePhase.inactive)
+            provider?.publishLifecycle(ApplicationLifecycleEventKind.willResignActive)
         }
     }
     override func onActivitySaveInstanceState(activity: Activity, outState: android.os.Bundle) {}

--- a/Sources/SkipDevice/ApplicationRuntimeProvider.swift
+++ b/Sources/SkipDevice/ApplicationRuntimeProvider.swift
@@ -1,0 +1,356 @@
+// Copyright 2025-2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+#if !SKIP_BRIDGE
+import Foundation
+#if canImport(OSLog)
+import OSLog
+#endif
+#if !SKIP
+#if canImport(UIKit)
+import UIKit
+#endif
+#else
+import android.app.Activity
+import android.app.Application
+import android.content.ComponentCallbacks2
+import android.content.res.Configuration
+#endif
+
+private let applicationRuntimeLogger: Logger = Logger(subsystem: "skip.device", category: "ApplicationRuntimeProvider") // adb logcat '*:S' 'skip.device.ApplicationRuntimeProvider:V'
+
+/// A provider for app lifecycle and memory pressure events.
+public final class ApplicationRuntimeProvider: @unchecked Sendable {
+    #if SKIP
+    private var androidObserver: ApplicationRuntimeAndroidObserver?
+    #else
+    private var notificationObservers: [NSObjectProtocol] = []
+    #endif
+
+    private let lock = NSLock()
+    private var lifecycleMonitors: [LifecycleMonitor] = []
+    private var memoryMonitors: [MemoryMonitor] = []
+    private var lifecyclePhase: ApplicationLifecyclePhase = .unknown
+
+    public init() {
+        #if !SKIP
+        lifecyclePhase = Self.initialLifecyclePhase()
+        #endif
+        start()
+    }
+
+    deinit {
+        stop()
+    }
+
+    /// The most recently observed app lifecycle phase.
+    public var currentLifecyclePhase: ApplicationLifecyclePhase {
+        lock.lock()
+        let phase = lifecyclePhase
+        lock.unlock()
+        return phase
+    }
+
+    /// Monitors foreground/background lifecycle events.
+    public func monitorLifecycle() -> AsyncStream<ApplicationLifecycleEvent> {
+        let id = UUID()
+        return AsyncStream { continuation in
+            lock.lock()
+            lifecycleMonitors.append(LifecycleMonitor(
+                id: id,
+                yield: { event in
+                    continuation.yield(event)
+                },
+                finish: {
+                    continuation.finish()
+                }
+            ))
+            let phase = lifecyclePhase
+            lock.unlock()
+            continuation.yield(ApplicationLifecycleEvent(phase: phase))
+            continuation.onTermination = { [weak self] _ in
+                self?.removeLifecycleContinuation(id)
+            }
+        }
+    }
+
+    /// Monitors memory pressure events.
+    public func monitorMemoryPressure() -> AsyncStream<MemoryPressureEvent> {
+        let id = UUID()
+        return AsyncStream { continuation in
+            lock.lock()
+            memoryMonitors.append(MemoryMonitor(
+                id: id,
+                yield: { event in
+                    continuation.yield(event)
+                },
+                finish: {
+                    continuation.finish()
+                }
+            ))
+            lock.unlock()
+            continuation.onTermination = { [weak self] _ in
+                self?.removeMemoryContinuation(id)
+            }
+        }
+    }
+
+    /// Stops monitoring platform runtime callbacks and finishes active streams.
+    public func stop() {
+        #if SKIP
+        androidObserver?.stop()
+        androidObserver = nil
+        #else
+        for observer in notificationObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        notificationObservers.removeAll()
+        #endif
+
+        lock.lock()
+        let lifecycle = lifecycleMonitors
+        lifecycleMonitors.removeAll()
+        let memory = memoryMonitors
+        memoryMonitors.removeAll()
+        lock.unlock()
+
+        for monitor in lifecycle {
+            monitor.finish()
+        }
+        for monitor in memory {
+            monitor.finish()
+        }
+    }
+
+    func publishLifecycle(_ phase: ApplicationLifecyclePhase) {
+        let event = ApplicationLifecycleEvent(phase: phase)
+        lock.lock()
+        lifecyclePhase = phase
+        let monitors = lifecycleMonitors
+        lock.unlock()
+        for monitor in monitors {
+            monitor.yield(event)
+        }
+    }
+
+    func publishMemoryPressure(_ level: MemoryPressureLevel) {
+        let event = MemoryPressureEvent(level: level)
+        lock.lock()
+        let monitors = memoryMonitors
+        lock.unlock()
+        for monitor in monitors {
+            monitor.yield(event)
+        }
+    }
+
+    private func removeLifecycleContinuation(_ id: UUID) {
+        lock.lock()
+        var kept: [LifecycleMonitor] = []
+        for monitor in lifecycleMonitors {
+            if monitor.id != id {
+                kept.append(monitor)
+            }
+        }
+        lifecycleMonitors = kept
+        lock.unlock()
+    }
+
+    private func removeMemoryContinuation(_ id: UUID) {
+        lock.lock()
+        var kept: [MemoryMonitor] = []
+        for monitor in memoryMonitors {
+            if monitor.id != id {
+                kept.append(monitor)
+            }
+        }
+        memoryMonitors = kept
+        lock.unlock()
+    }
+
+    private func start() {
+        #if SKIP
+        guard androidObserver == nil else {
+            return
+        }
+        let observer = ApplicationRuntimeAndroidObserver(provider: self)
+        observer.start()
+        androidObserver = observer
+        #else
+        guard notificationObservers.isEmpty else {
+            return
+        }
+        #if canImport(UIKit)
+        let center = NotificationCenter.default
+        notificationObservers.append(center.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
+            self?.publishLifecycle(ApplicationLifecyclePhase.active)
+        })
+        notificationObservers.append(center.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: nil) { [weak self] _ in
+            self?.publishLifecycle(ApplicationLifecyclePhase.inactive)
+        })
+        notificationObservers.append(center.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { [weak self] _ in
+            self?.publishLifecycle(ApplicationLifecyclePhase.background)
+        })
+        notificationObservers.append(center.addObserver(forName: UIApplication.willTerminateNotification, object: nil, queue: nil) { [weak self] _ in
+            self?.publishLifecycle(ApplicationLifecyclePhase.terminated)
+        })
+        notificationObservers.append(center.addObserver(forName: UIApplication.didReceiveMemoryWarningNotification, object: nil, queue: nil) { [weak self] _ in
+            self?.publishMemoryPressure(MemoryPressureLevel.warning)
+        })
+        #endif
+        #endif
+    }
+
+    #if !SKIP
+    private static func initialLifecyclePhase() -> ApplicationLifecyclePhase {
+        #if canImport(UIKit)
+        guard Thread.isMainThread else {
+            return ApplicationLifecyclePhase.unknown
+        }
+        return MainActor.assumeIsolated {
+            switch UIApplication.shared.applicationState {
+            case .active:
+                return ApplicationLifecyclePhase.active
+            case .inactive:
+                return ApplicationLifecyclePhase.inactive
+            case .background:
+                return ApplicationLifecyclePhase.background
+            @unknown default:
+                return ApplicationLifecyclePhase.unknown
+            }
+        }
+        #else
+        return ApplicationLifecyclePhase.unknown
+        #endif
+    }
+    #endif
+}
+
+private struct LifecycleMonitor {
+    var id: UUID
+    var yield: (ApplicationLifecycleEvent) -> Void
+    var finish: () -> Void
+}
+
+private struct MemoryMonitor {
+    var id: UUID
+    var yield: (MemoryPressureEvent) -> Void
+    var finish: () -> Void
+}
+
+/// A coarse app lifecycle phase.
+public enum ApplicationLifecyclePhase: String, Hashable, Sendable {
+    case active
+    case inactive
+    case background
+    case terminated
+    case unknown
+}
+
+/// A coarse memory pressure level.
+public enum MemoryPressureLevel: String, Hashable, Sendable {
+    case warning
+    case critical
+}
+
+/// An app lifecycle event.
+public struct ApplicationLifecycleEvent: Hashable, Sendable {
+    /// The lifecycle phase that was observed.
+    public var phase: ApplicationLifecyclePhase
+    /// The event timestamp in seconds since 1970.
+    public var timestamp: TimeInterval
+
+    public init(phase: ApplicationLifecyclePhase, timestamp: TimeInterval = Date().timeIntervalSince1970) {
+        self.phase = phase
+        self.timestamp = timestamp
+    }
+}
+
+/// A memory pressure event.
+public struct MemoryPressureEvent: Hashable, Sendable {
+    /// The memory pressure level that was observed.
+    public var level: MemoryPressureLevel
+    /// The event timestamp in seconds since 1970.
+    public var timestamp: TimeInterval
+
+    public init(level: MemoryPressureLevel, timestamp: TimeInterval = Date().timeIntervalSince1970) {
+        self.level = level
+        self.timestamp = timestamp
+    }
+}
+
+#if SKIP
+private final class ApplicationRuntimeAndroidObserver: Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
+    private weak var provider: ApplicationRuntimeProvider?
+    private let application: Application?
+    private var startedActivities = 0
+    private var resumedActivities = 0
+
+    init(provider: ApplicationRuntimeProvider) {
+        self.provider = provider
+        self.application = ProcessInfo.processInfo.androidContext.applicationContext as? Application
+    }
+
+    func start() {
+        application?.registerActivityLifecycleCallbacks(self)
+        application?.registerComponentCallbacks(self)
+    }
+
+    func stop() {
+        application?.unregisterActivityLifecycleCallbacks(self)
+        application?.unregisterComponentCallbacks(self)
+    }
+
+    override func onActivityResumed(activity: Activity) {
+        resumedActivities += 1
+        provider?.publishLifecycle(ApplicationLifecyclePhase.active)
+    }
+
+    override func onActivityPaused(activity: Activity) {
+        if resumedActivities > 0 {
+            resumedActivities -= 1
+        }
+        if resumedActivities == 0 && startedActivities > 0 {
+            provider?.publishLifecycle(ApplicationLifecyclePhase.inactive)
+        }
+    }
+
+    override func onActivityStopped(activity: Activity) {
+        if startedActivities > 0 {
+            startedActivities -= 1
+        }
+        if startedActivities == 0 {
+            provider?.publishLifecycle(ApplicationLifecyclePhase.background)
+        }
+    }
+
+    override func onActivityDestroyed(activity: Activity) {
+        if activity.isFinishing && startedActivities == 0 {
+            provider?.publishLifecycle(ApplicationLifecyclePhase.terminated)
+        }
+    }
+
+    override func onActivityCreated(activity: Activity, savedInstanceState: android.os.Bundle?) {}
+    override func onActivityStarted(activity: Activity) {
+        startedActivities += 1
+        if resumedActivities == 0 {
+            provider?.publishLifecycle(ApplicationLifecyclePhase.inactive)
+        }
+    }
+    override func onActivitySaveInstanceState(activity: Activity, outState: android.os.Bundle) {}
+
+    override func onLowMemory() {
+        provider?.publishMemoryPressure(MemoryPressureLevel.critical)
+    }
+
+    override func onTrimMemory(level: Int) {
+        if level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL || level == ComponentCallbacks2.TRIM_MEMORY_COMPLETE {
+            provider?.publishMemoryPressure(MemoryPressureLevel.critical)
+        } else {
+            provider?.publishMemoryPressure(MemoryPressureLevel.warning)
+        }
+    }
+
+    override func onConfigurationChanged(newConfig: Configuration) {}
+}
+#endif
+
+#endif

--- a/Sources/SkipDevice/BackgroundActivity.swift
+++ b/Sources/SkipDevice/BackgroundActivity.swift
@@ -1,0 +1,335 @@
+// Copyright 2025-2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+#if !SKIP_BRIDGE
+import Foundation
+#if canImport(OSLog)
+import OSLog
+#endif
+#if !SKIP
+#if canImport(UIKit)
+import UIKit
+#endif
+#else
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+#endif
+
+private let backgroundActivityLogger: Logger = Logger(subsystem: "skip.device", category: "BackgroundActivity") // adb logcat '*:S' 'skip.device.BackgroundActivity:V'
+
+/// Starts and ends finite user-visible background work.
+public final class BackgroundActivity {
+    private init() {
+    }
+
+    /// Begins a finite background activity and returns its identifier.
+    public static func begin(_ request: BackgroundActivityRequest) async throws -> String {
+        #if SKIP
+        return try BackgroundActivityAndroidHost.begin(request)
+        #elseif canImport(UIKit)
+        return try await MainActor.run {
+            let identifier = UUID().uuidString
+            let task = UIApplication.shared.beginBackgroundTask(withName: request.name) {
+                Task { @MainActor in
+                    BackgroundActivityDarwinRegistry.shared.expire(identifier)
+                }
+            }
+            guard task != .invalid else {
+                throw BackgroundActivityError(errorDescription: "Unable to begin background activity.")
+            }
+            BackgroundActivityDarwinRegistry.shared.store(identifier: identifier, task: task)
+            return identifier
+        }
+        #else
+        throw BackgroundActivityError(errorDescription: "Background activity is not available on this platform.")
+        #endif
+    }
+
+    /// Ends a background activity previously returned by `begin(_:)`.
+    public static func end(_ identifier: String) async {
+        #if SKIP
+        BackgroundActivityAndroidHost.end(identifier)
+        #elseif canImport(UIKit)
+        await MainActor.run {
+            BackgroundActivityDarwinRegistry.shared.end(identifier)
+        }
+        #endif
+    }
+
+    #if SKIP
+    static func serviceType(for reason: BackgroundActivityReason) -> Int {
+        switch reason {
+        case BackgroundActivityReason.localNetworkTransfer:
+            return ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        case BackgroundActivityReason.mediaProcessing:
+            if Build.VERSION.SDK_INT >= 35 {
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROCESSING
+            }
+            return ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        case BackgroundActivityReason.connectedDeviceTransfer:
+            return ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+        case BackgroundActivityReason.shortCriticalWork:
+            if Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE {
+                return ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+            }
+            return ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        }
+    }
+    #endif
+}
+
+/// Describes a finite background activity.
+public struct BackgroundActivityRequest: Hashable, Sendable {
+    /// User-visible activity name.
+    public var name: String
+    /// The platform reason used to choose an Android foreground-service type.
+    public var reason: BackgroundActivityReason
+    /// Optional user-visible detail for the Android foreground notification.
+    public var detail: String
+    /// Android notification channel identifier.
+    public var notificationChannelID: String
+    /// Android foreground notification identifier.
+    public var notificationID: Int
+    /// Android drawable resource name for the foreground notification icon.
+    public var notificationIconResourceName: String
+
+    public init(
+        name: String,
+        reason: BackgroundActivityReason = BackgroundActivityReason.shortCriticalWork,
+        detail: String = "",
+        notificationChannelID: String = "tools.skip.device.background_activity",
+        notificationID: Int = 41_001,
+        notificationIconResourceName: String = "ic_notification"
+    ) {
+        self.name = name
+        self.reason = reason
+        self.detail = detail
+        self.notificationChannelID = notificationChannelID
+        self.notificationID = notificationID
+        self.notificationIconResourceName = notificationIconResourceName
+    }
+}
+
+/// The reason a background activity needs additional runtime.
+public enum BackgroundActivityReason: String, Hashable, Sendable {
+    case localNetworkTransfer
+    case mediaProcessing
+    case connectedDeviceTransfer
+    case shortCriticalWork
+}
+
+/// An error starting or managing a background activity.
+public struct BackgroundActivityError: LocalizedError {
+    public var errorDescription: String?
+
+    public init(errorDescription: String?) {
+        self.errorDescription = errorDescription
+    }
+}
+
+#if !SKIP && canImport(UIKit)
+@MainActor
+private final class BackgroundActivityDarwinRegistry: @unchecked Sendable {
+    static let shared = BackgroundActivityDarwinRegistry()
+
+    private let lock = NSLock()
+    private var tasks: [String: UIBackgroundTaskIdentifier] = [:]
+
+    private init() {
+    }
+
+    func store(identifier: String, task: UIBackgroundTaskIdentifier) {
+        lock.lock()
+        tasks[identifier] = task
+        lock.unlock()
+    }
+
+    func end(_ identifier: String) {
+        lock.lock()
+        let task = tasks.removeValue(forKey: identifier)
+        lock.unlock()
+        if let task {
+            UIApplication.shared.endBackgroundTask(task)
+        }
+    }
+
+    func expire(_ identifier: String) {
+        end(identifier)
+    }
+}
+#endif
+
+#if SKIP
+private enum BackgroundActivityAndroidHost {
+    static func begin(_ request: BackgroundActivityRequest) throws -> String {
+        let identifier = UUID().uuidString
+        let context = ProcessInfo.processInfo.androidContext.applicationContext
+        let intent = BackgroundActivityService.intent(context: context)
+        intent.setAction(BackgroundActivityService.actionBegin)
+        intent.putExtra(BackgroundActivityService.extraIdentifier, identifier)
+        intent.putExtra(BackgroundActivityService.extraName, request.name)
+        intent.putExtra(BackgroundActivityService.extraReason, request.reason.rawValue)
+        intent.putExtra(BackgroundActivityService.extraDetail, request.detail)
+        intent.putExtra(BackgroundActivityService.extraChannelID, request.notificationChannelID)
+        intent.putExtra(BackgroundActivityService.extraNotificationID, request.notificationID)
+        intent.putExtra(BackgroundActivityService.extraIconResourceName, request.notificationIconResourceName)
+        do {
+            ContextCompat.startForegroundService(context, intent)
+            return identifier
+        } catch {
+            throw BackgroundActivityError(errorDescription: "Unable to begin background activity: \(error)")
+        }
+    }
+
+    static func end(_ identifier: String) {
+        let context = ProcessInfo.processInfo.androidContext.applicationContext
+        let intent = BackgroundActivityService.intent(context: context)
+        intent.setAction(BackgroundActivityService.actionEnd)
+        intent.putExtra(BackgroundActivityService.extraIdentifier, identifier)
+        context.startService(intent)
+    }
+}
+
+/// Generic foreground service backing Android background activities.
+class BackgroundActivityService: Service {
+    static let actionBegin = "tools.skip.device.background_activity.BEGIN"
+    static let actionEnd = "tools.skip.device.background_activity.END"
+    static let extraIdentifier = "tools.skip.device.background_activity.identifier"
+    static let extraName = "tools.skip.device.background_activity.name"
+    static let extraReason = "tools.skip.device.background_activity.reason"
+    static let extraDetail = "tools.skip.device.background_activity.detail"
+    static let extraChannelID = "tools.skip.device.background_activity.channel_id"
+    static let extraNotificationID = "tools.skip.device.background_activity.notification_id"
+    static let extraIconResourceName = "tools.skip.device.background_activity.icon_resource_name"
+
+    private var activeRequests: [String: BackgroundActivityRequest] = [:]
+
+    override init() {
+        super.init()
+    }
+
+    static func intent(context: Context) -> Intent {
+        let intent = Intent()
+        intent.setClassName(context, "skip.device.BackgroundActivityService")
+        return intent
+    }
+
+    override func onBind(intent: Intent?) -> IBinder? {
+        return nil
+    }
+
+    override func onStartCommand(intent: Intent?, flags: Int, startId: Int) -> Int {
+        guard let intent else {
+            return Service.START_NOT_STICKY
+        }
+
+        let action = intent.getAction()
+        let identifier = intent.getStringExtra(Self.extraIdentifier) ?? ""
+        if action == Self.actionBegin {
+            guard let request = request(from: intent) else {
+                stopSelf(startId)
+                return Service.START_NOT_STICKY
+            }
+            activeRequests[identifier] = request
+            startForeground(for: request)
+        } else if action == Self.actionEnd {
+            activeRequests[identifier] = nil
+            if let request = activeRequests.values.first {
+                startForeground(for: request)
+            } else {
+                ServiceCompat.stopForeground(self, ServiceCompat.STOP_FOREGROUND_REMOVE)
+                stopSelf()
+            }
+        }
+
+        return Service.START_NOT_STICKY
+    }
+
+    override func onTimeout(startId: Int) {
+        activeRequests.removeAll()
+        stopSelf(startId)
+    }
+
+    override func onTimeout(startId: Int, fgsType: Int) {
+        activeRequests.removeAll()
+        stopSelf(startId)
+    }
+
+    private func request(from intent: Intent) -> BackgroundActivityRequest? {
+        guard let name = intent.getStringExtra(Self.extraName), !name.isEmpty else {
+            return nil
+        }
+        let reasonRawValue = intent.getStringExtra(Self.extraReason) ?? BackgroundActivityReason.shortCriticalWork.rawValue
+        let reason = BackgroundActivityReason(rawValue: reasonRawValue) ?? BackgroundActivityReason.shortCriticalWork
+        let detail = intent.getStringExtra(Self.extraDetail) ?? ""
+        let channelID = intent.getStringExtra(Self.extraChannelID) ?? "tools.skip.device.background_activity"
+        let notificationID = intent.getIntExtra(Self.extraNotificationID, 41_001)
+        let iconResourceName = intent.getStringExtra(Self.extraIconResourceName) ?? "ic_notification"
+        return BackgroundActivityRequest(
+            name: name,
+            reason: reason,
+            detail: detail,
+            notificationChannelID: channelID,
+            notificationID: notificationID,
+            notificationIconResourceName: iconResourceName
+        )
+    }
+
+    private func startForeground(for request: BackgroundActivityRequest) {
+        createNotificationChannel(request.notificationChannelID)
+        let notification = notificationBuilder(for: request).build()
+        let serviceType = BackgroundActivity.serviceType(for: request.reason)
+        ServiceCompat.startForeground(self, request.notificationID, notification, serviceType)
+    }
+
+    private func createNotificationChannel(_ channelID: String) {
+        if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O {
+            let notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            let appName = getApplicationInfo().loadLabel(getPackageManager()).toString()
+            notificationManager.createNotificationChannel(NotificationChannel(channelID, appName, NotificationManager.IMPORTANCE_LOW))
+        }
+    }
+
+    private func notificationBuilder(for request: BackgroundActivityRequest) -> NotificationCompat.Builder {
+        let builder = NotificationCompat.Builder(self, request.notificationChannelID)
+        builder.setContentTitle(request.name)
+        builder.setOngoing(true)
+        builder.setSmallIcon(notificationIconResourceID(named: request.notificationIconResourceName))
+
+        if !request.detail.isEmpty {
+            builder.setContentText(request.detail)
+        }
+        if let launchIntent = getPackageManager().getLaunchIntentForPackage(getPackageName()) {
+            let flags = PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
+            let pendingIntent = PendingIntent.getActivity(self, request.notificationID, launchIntent, flags)
+            builder.setContentIntent(pendingIntent)
+        }
+        return builder
+    }
+
+    private func notificationIconResourceID(named name: String) -> Int {
+        var resourceID = getResources().getIdentifier(name, "drawable", getPackageName())
+        if resourceID == 0 {
+            resourceID = getResources().getIdentifier("ic_notification", "drawable", getPackageName())
+        }
+        if resourceID == 0 {
+            resourceID = getResources().getIdentifier("ic_launcher", "mipmap", getPackageName())
+        }
+        if resourceID == 0 {
+            resourceID = android.R.drawable.stat_sys_upload
+        }
+        return resourceID
+    }
+}
+#endif
+
+#endif

--- a/Sources/SkipDevice/DeviceIdentity.swift
+++ b/Sources/SkipDevice/DeviceIdentity.swift
@@ -77,17 +77,22 @@ public struct DeviceIdentity: Hashable, Sendable {
             product: Build.PRODUCT
         )
         #elseif canImport(UIKit)
-        let device = UIDevice.current
-        return DeviceIdentity(
-            name: device.name,
-            model: device.model,
-            localizedModel: device.localizedModel,
-            systemName: device.systemName,
-            systemVersion: device.systemVersion,
-            vendorIdentifier: device.identifierForVendor?.uuidString,
-            manufacturer: "Apple",
-            brand: "Apple"
-        )
+        guard Thread.isMainThread else {
+            return appleFallbackIdentity()
+        }
+        return MainActor.assumeIsolated {
+            let device = UIDevice.current
+            return DeviceIdentity(
+                name: device.name,
+                model: device.model,
+                localizedModel: device.localizedModel,
+                systemName: device.systemName,
+                systemVersion: device.systemVersion,
+                vendorIdentifier: device.identifierForVendor?.uuidString,
+                manufacturer: "Apple",
+                brand: "Apple"
+            )
+        }
         #else
         return DeviceIdentity(
             name: Host.current().localizedName,
@@ -105,6 +110,34 @@ public struct DeviceIdentity: Hashable, Sendable {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
+
+    #if !SKIP && canImport(UIKit)
+    private static func appleFallbackIdentity() -> DeviceIdentity {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return DeviceIdentity(
+            systemName: appleSystemName(),
+            systemVersion: "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)",
+            manufacturer: "Apple",
+            brand: "Apple"
+        )
+    }
+
+    private static func appleSystemName() -> String {
+        #if os(tvOS)
+        return "tvOS"
+        #elseif os(watchOS)
+        return "watchOS"
+        #elseif os(visionOS)
+        return "visionOS"
+        #elseif targetEnvironment(macCatalyst)
+        return "macOS"
+        #elseif os(iOS)
+        return "iOS"
+        #else
+        return "Apple"
+        #endif
+    }
+    #endif
 
     #if !SKIP && !canImport(UIKit)
     private static func machineIdentifier() -> String? {

--- a/Sources/SkipDevice/DeviceIdentity.swift
+++ b/Sources/SkipDevice/DeviceIdentity.swift
@@ -1,0 +1,121 @@
+// Copyright 2025-2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+#if !SKIP_BRIDGE
+import Foundation
+#if !SKIP
+#if canImport(UIKit)
+import UIKit
+#endif
+#else
+import android.os.Build
+import android.provider.Settings
+#endif
+
+/// Describes the current device using stable, low-level platform identity fields.
+public struct DeviceIdentity: Hashable, Sendable {
+    /// User-visible device name when the platform exposes one.
+    public var name: String?
+    /// Platform model string, such as an Apple model identifier or Android `Build.MODEL`.
+    public var model: String?
+    /// Localized Apple model string when available.
+    public var localizedModel: String?
+    /// Platform operating system name.
+    public var systemName: String?
+    /// Platform operating system version.
+    public var systemVersion: String?
+    /// App/vendor-scoped stable identifier when available.
+    public var vendorIdentifier: String?
+    /// Device manufacturer, such as `Apple`, `Google`, or `Samsung`.
+    public var manufacturer: String?
+    /// Android `Build.BRAND` when available.
+    public var brand: String?
+    /// Android `Build.DEVICE` when available.
+    public var device: String?
+    /// Android `Build.PRODUCT` when available.
+    public var product: String?
+
+    public init(
+        name: String? = nil,
+        model: String? = nil,
+        localizedModel: String? = nil,
+        systemName: String? = nil,
+        systemVersion: String? = nil,
+        vendorIdentifier: String? = nil,
+        manufacturer: String? = nil,
+        brand: String? = nil,
+        device: String? = nil,
+        product: String? = nil
+    ) {
+        self.name = Self.nonEmpty(name)
+        self.model = Self.nonEmpty(model)
+        self.localizedModel = Self.nonEmpty(localizedModel)
+        self.systemName = Self.nonEmpty(systemName)
+        self.systemVersion = Self.nonEmpty(systemVersion)
+        self.vendorIdentifier = Self.nonEmpty(vendorIdentifier)
+        self.manufacturer = Self.nonEmpty(manufacturer)
+        self.brand = Self.nonEmpty(brand)
+        self.device = Self.nonEmpty(device)
+        self.product = Self.nonEmpty(product)
+    }
+
+    /// Returns the current platform device identity.
+    public static var current: DeviceIdentity {
+        #if SKIP
+        let context = ProcessInfo.processInfo.androidContext
+        let contentResolver = context.contentResolver
+        let deviceName = Settings.Global.getString(contentResolver, "device_name")
+        let androidID = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID)
+        return DeviceIdentity(
+            name: deviceName,
+            model: Build.MODEL,
+            systemName: "Android",
+            systemVersion: Build.VERSION.RELEASE,
+            vendorIdentifier: androidID,
+            manufacturer: Build.MANUFACTURER,
+            brand: Build.BRAND,
+            device: Build.DEVICE,
+            product: Build.PRODUCT
+        )
+        #elseif canImport(UIKit)
+        let device = UIDevice.current
+        return DeviceIdentity(
+            name: device.name,
+            model: device.model,
+            localizedModel: device.localizedModel,
+            systemName: device.systemName,
+            systemVersion: device.systemVersion,
+            vendorIdentifier: device.identifierForVendor?.uuidString,
+            manufacturer: "Apple",
+            brand: "Apple"
+        )
+        #else
+        return DeviceIdentity(
+            name: Host.current().localizedName,
+            model: machineIdentifier(),
+            systemName: ProcessInfo.processInfo.operatingSystemVersionString,
+            systemVersion: ProcessInfo.processInfo.operatingSystemVersionString
+        )
+        #endif
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    #if !SKIP && !canImport(UIKit)
+    private static func machineIdentifier() -> String? {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        return withUnsafePointer(to: &systemInfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                String(validatingCString: $0)
+            }
+        }
+    }
+    #endif
+}
+#endif

--- a/Sources/SkipDevice/Skip/skip.yml
+++ b/Sources/SkipDevice/Skip/skip.yml
@@ -3,8 +3,8 @@ skip:
   bridging: true
 
 # Kotlin dependencies and Gradle build options for this module can be configured here
-#build:
-#  contents:
-#    - block: 'dependencies'
-#      contents:
-#        - 'implementation("…")'
+build:
+  contents:
+    - block: 'dependencies'
+      contents:
+        - 'implementation("androidx.core:core:1.13.1")'

--- a/Tests/SkipDeviceTests/Skip/AndroidManifest.xml
+++ b/Tests/SkipDeviceTests/Skip/AndroidManifest.xml
@@ -8,4 +8,15 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROCESSING" />
+
+    <application>
+        <service
+            android:name="skip.device.BackgroundActivityService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync|mediaProcessing|connectedDevice|shortService" />
+    </application>
 </manifest>

--- a/Tests/SkipDeviceTests/SkipDeviceTests.swift
+++ b/Tests/SkipDeviceTests/SkipDeviceTests.swift
@@ -14,6 +14,73 @@ final class SkipDeviceTests: XCTestCase {
         XCTAssertTrue(isReachable, "expected the network to be reachable")
     }
 
+    func testBackgroundActivityRequestDefaults() {
+        let request = BackgroundActivityRequest(name: "Sync")
+        XCTAssertEqual(request.name, "Sync")
+        XCTAssertEqual(request.reason, BackgroundActivityReason.shortCriticalWork)
+        XCTAssertEqual(request.detail, "")
+        XCTAssertEqual(request.notificationChannelID, "tools.skip.device.background_activity")
+        XCTAssertEqual(request.notificationID, 41_001)
+        XCTAssertEqual(request.notificationIconResourceName, "ic_notification")
+    }
+
+    func testBackgroundActivityRequestCustomValues() {
+        let request = BackgroundActivityRequest(
+            name: "Proxy media",
+            reason: BackgroundActivityReason.localNetworkTransfer,
+            detail: "Streaming to a receiver",
+            notificationChannelID: "custom.channel",
+            notificationID: 7,
+            notificationIconResourceName: "custom_icon"
+        )
+        XCTAssertEqual(request.name, "Proxy media")
+        XCTAssertEqual(request.reason, BackgroundActivityReason.localNetworkTransfer)
+        XCTAssertEqual(request.detail, "Streaming to a receiver")
+        XCTAssertEqual(request.notificationChannelID, "custom.channel")
+        XCTAssertEqual(request.notificationID, 7)
+        XCTAssertEqual(request.notificationIconResourceName, "custom_icon")
+    }
+
+    func testApplicationRuntimeProviderPublishesLifecycleEvents() async {
+        let provider = ApplicationRuntimeProvider()
+        var iterator = provider.monitorLifecycle().makeAsyncIterator()
+        _ = await iterator.next()
+
+        provider.publishLifecycle(ApplicationLifecyclePhase.background)
+
+        let event = await iterator.next()
+        XCTAssertEqual(event?.phase, ApplicationLifecyclePhase.background)
+        provider.stop()
+    }
+
+    func testApplicationRuntimeProviderPublishesMemoryPressureEvents() async {
+        let provider = ApplicationRuntimeProvider()
+        var iterator = provider.monitorMemoryPressure().makeAsyncIterator()
+
+        provider.publishMemoryPressure(MemoryPressureLevel.critical)
+
+        let event = await iterator.next()
+        XCTAssertEqual(event?.level, MemoryPressureLevel.critical)
+        provider.stop()
+    }
+
+    #if SKIP
+    func testBackgroundActivityReasonServiceTypeMapping() {
+        XCTAssertEqual(BackgroundActivity.serviceType(for: BackgroundActivityReason.localNetworkTransfer), android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        XCTAssertEqual(BackgroundActivity.serviceType(for: BackgroundActivityReason.connectedDeviceTransfer), android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE)
+        if android.os.Build.VERSION.SDK_INT >= 35 {
+            XCTAssertEqual(BackgroundActivity.serviceType(for: BackgroundActivityReason.mediaProcessing), android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROCESSING)
+        } else {
+            XCTAssertEqual(BackgroundActivity.serviceType(for: BackgroundActivityReason.mediaProcessing), android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        }
+        if android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE {
+            XCTAssertEqual(BackgroundActivity.serviceType(for: BackgroundActivityReason.shortCriticalWork), android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE)
+        } else {
+            XCTAssertEqual(BackgroundActivity.serviceType(for: BackgroundActivityReason.shortCriticalWork), android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        }
+    }
+    #endif
+
     func testLocationProvier() async throws {
         let lp = LocationProvider()
 

--- a/Tests/SkipDeviceTests/SkipDeviceTests.swift
+++ b/Tests/SkipDeviceTests/SkipDeviceTests.swift
@@ -46,11 +46,19 @@ final class SkipDeviceTests: XCTestCase {
         var iterator = provider.monitorLifecycle().makeAsyncIterator()
         _ = await iterator.next()
 
-        provider.publishLifecycle(ApplicationLifecyclePhase.background)
+        provider.publishLifecycle(ApplicationLifecycleEventKind.didEnterBackground)
 
         let event = await iterator.next()
+        XCTAssertEqual(event?.kind, ApplicationLifecycleEventKind.didEnterBackground)
         XCTAssertEqual(event?.phase, ApplicationLifecyclePhase.background)
         provider.stop()
+    }
+
+    func testApplicationLifecycleEventPhaseInitializerSetsMatchingKind() {
+        let event = ApplicationLifecycleEvent(phase: ApplicationLifecyclePhase.active)
+
+        XCTAssertEqual(event.kind, ApplicationLifecycleEventKind.didBecomeActive)
+        XCTAssertEqual(event.phase, ApplicationLifecyclePhase.active)
     }
 
     func testApplicationRuntimeProviderPublishesMemoryPressureEvents() async {

--- a/Tests/SkipDeviceTests/SkipDeviceTests.swift
+++ b/Tests/SkipDeviceTests/SkipDeviceTests.swift
@@ -14,6 +14,26 @@ final class SkipDeviceTests: XCTestCase {
         XCTAssertTrue(isReachable, "expected the network to be reachable")
     }
 
+    func testDeviceIdentityValueConstructionTrimsEmptyStrings() {
+        let identity = DeviceIdentity(
+            name: "  Pixel  ",
+            model: "  ",
+            systemName: "Android",
+            manufacturer: "Google"
+        )
+
+        XCTAssertEqual(identity.name, "Pixel")
+        XCTAssertNil(identity.model)
+        XCTAssertEqual(identity.systemName, "Android")
+        XCTAssertEqual(identity.manufacturer, "Google")
+    }
+
+    func testDeviceIdentityCurrentHasPlatformName() {
+        let identity = DeviceIdentity.current
+
+        XCTAssertNotNil(identity.systemName)
+    }
+
     func testBackgroundActivityRequestDefaults() {
         let request = BackgroundActivityRequest(name: "Sync")
         XCTAssertEqual(request.name, "Sync")


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code, manually validate from a sandbox native app

-----



## Summary

Adds three dual-platform device/app-shell capabilities to `SkipDevice`:

- `ApplicationRuntimeProvider` for app lifecycle and memory pressure events
- `BackgroundActivity` for finite user-visible background work
- `DeviceIdentity.current` for basic platform device metadata

## Changes

### Application runtime events

Adds `ApplicationRuntimeProvider`, which exposes:

- `currentLifecyclePhase`
- `monitorLifecycle() -> AsyncStream<ApplicationLifecycleEvent>`
- `monitorMemoryPressure() -> AsyncStream<MemoryPressureEvent>`
- `stop()`

On Apple platforms this uses `UIApplication` notifications for lifecycle and memory warnings.

On Android this uses:

- `Application.ActivityLifecycleCallbacks` for lifecycle
- `ComponentCallbacks2` for memory pressure

Android memory pressure maps `onLowMemory`, `TRIM_MEMORY_RUNNING_CRITICAL`, and `TRIM_MEMORY_COMPLETE` to `.critical`; other trim callbacks map to `.warning`.

Lifecycle events expose both:

- `kind`, preserving iOS-style event names where possible
- `phase`, a normalized app phase

### Background activity

Adds `BackgroundActivity.begin(_:)` / `BackgroundActivity.end(_:)` for finite background work.

On iOS/tvOS this wraps `UIApplication.beginBackgroundTask` and `endBackgroundTask`.

On Android this adds a generic `BackgroundActivityService` foreground service with a registry of active activity IDs. The service stops when no activities remain.

Android foreground-service type mapping:

| Reason | Android foreground service type |
|---|---|
| `localNetworkTransfer` | `dataSync` |
| `mediaProcessing` | `mediaProcessing` on Android 15+, `dataSync` fallback |
| `connectedDeviceTransfer` | `connectedDevice` |
| `shortCriticalWork` | `shortService` when available, `dataSync` fallback |

The Android service implements foreground-service timeout handling and stops promptly when Android reports a timeout.

### Device identity

Adds `DeviceIdentity.current`, exposing low-level device metadata:

- `name`
- `model`
- `localizedModel`
- `systemName`
- `systemVersion`
- `vendorIdentifier`
- `manufacturer`
- `brand`
- `device`
- `product`

On Apple platforms this wraps `UIDevice`. On Android this reads from `Build`, `Settings.Global`, and `Settings.Secure`.

`vendorIdentifier` maps to `UIDevice.identifierForVendor` on Apple platforms and `Settings.Secure.ANDROID_ID` on Android.

### Android setup

Adds an `androidx.core:core` dependency for `NotificationCompat`, `ServiceCompat`, and `ContextCompat`.

Updates README documentation with required Android manifest entries for apps using `BackgroundActivity`, including foreground-service permissions and service declaration.


### Background task example usage

```swift
import SkipDevice

func runTransfer() async throws {
    let activityID = try await BackgroundActivity.begin(BackgroundActivityRequest(
        name: "Streaming to receiver",
        reason: .connectedDeviceTransfer,
        detail: "Maintaining the local transfer"
    ))

    do {
        try await streamToReceiver()
        await BackgroundActivity.end(activityID)
    } catch {
        await BackgroundActivity.end(activityID)
        throw error
    }
}
```

### Background task in the sandbox

Notice the number of `ticks` executed in the background, from the UI report + logs

https://github.com/user-attachments/assets/c59f44e0-34e0-48b1-92fd-97976a6dec82


