### PR TITLE
Use correct version gating of API 34 for the use of getMslAltitudeMeters()

### DIFF
--- a/Sources/SkipDevice/LocationProvider.swift
+++ b/Sources/SkipDevice/LocationProvider.swift
@@ -223,8 +223,9 @@ public struct LocationEvent: Hashable, Sendable {
         self.longitude = location.getLongitude()
         // some accessors may fail with precondition exceptions like `java.lang.IllegalStateException: The Mean Sea Level altitude of this location is not set.`, so we defensively check whether the property is set and fallback to empty values
         self.horizontalAccuracy = location.hasAccuracy() ? location.getAccuracy().toDouble() : 0.0
-        // `hasMslAltitude()`/`getMslAltitudeMeters()` were added in API 33 (Android 13); calling them on older devices throws NoSuchMethodError
-        if android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU, location.hasMslAltitude() {
+        // https://developer.android.com/reference/android/location/Location#getMslAltitudeMeters()
+        // `hasMslAltitude()`/`getMslAltitudeMeters()` were added in API 34 (Android 14); calling them on older devices throws NoSuchMethodError
+        if android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE, location.hasMslAltitude() {
             self.altitude = location.getMslAltitudeMeters()
         } else {
             self.altitude = 0.0


### PR DESCRIPTION
Our users were still experiencing crashes after this recent update, but on Android 13 devices only. With some research and testing, I confirmed that it was just the wrong API version gating for getting the MSL Altitude. 

Confirmed now to be working without crashing on an Android 13 (API 33) device.

------------
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

